### PR TITLE
Expose parametrization with alpha, not log_alpha

### DIFF
--- a/examples/plot_compare_optimizers.py
+++ b/examples/plot_compare_optimizers.py
@@ -54,17 +54,16 @@ n_samples = len(y[idx_train])
 alpha_max = np.max(np.abs(X[idx_train, :].T.dot(y[idx_train])))
 
 alpha_max /= 4 * len(idx_train)
-log_alpha_max = np.log(alpha_max)
-log_alpha_min = np.log(alpha_max / 100)
+alpha_max = alpha_max
+alpha_min = alpha_max / 100
 max_iter = 100
 
-log_alpha0 = np.log(0.1 * alpha_max)
+alpha0 = alpha_max / 10
 tol = 1e-8
 
 n_alphas = 30
 p_alphas = np.geomspace(1, 0.0001, n_alphas)
 alphas = alpha_max * p_alphas
-log_alphas = np.log(alphas)
 
 ##############################################################################
 # Grid-search
@@ -77,8 +76,8 @@ criterion = HeldOutLogistic(idx_train, idx_val)
 algo_grid = Forward()
 monitor_grid = Monitor()
 grid_search(
-    algo_grid, criterion, model, X, y, log_alpha_min, log_alpha_max,
-    monitor_grid, log_alphas=log_alphas, tol=tol)
+    algo_grid, criterion, model, X, y, alpha_min, alpha_max,
+    monitor_grid, alphas=alphas, tol=tol)
 objs = np.array(monitor_grid.objs)
 
 
@@ -104,7 +103,7 @@ for optimizer_name in optimizer_names:
 
     optimizer = optimizers[optimizer_name]
     grad_search(
-        algo, criterion, model, optimizer, X, y, log_alpha0,
+        algo, criterion, model, optimizer, X, y, alpha0,
         monitor_grad)
     monitors[optimizer_name] = monitor_grad
 
@@ -123,7 +122,7 @@ plt.semilogx(
     color=current_palette[1])
 for optimizer_name in optimizer_names:
     monitor = monitors[optimizer_name]
-    p_alphas_grad = np.exp(np.array(monitor.log_alphas)) / alpha_max
+    p_alphas_grad = np.array(monitor.alphas) / alpha_max
     objs_grad = np.array(monitor.objs)
     plt.semilogx(
         p_alphas_grad, objs_grad, 'bX', label=optimizer_name,

--- a/examples/plot_compare_optimizers.py
+++ b/examples/plot_compare_optimizers.py
@@ -57,7 +57,6 @@ alpha_max = alpha_max
 alpha_min = alpha_max / 100
 max_iter = 100
 
-alpha0 = alpha_max / 10
 tol = 1e-8
 
 n_alphas = 30
@@ -90,7 +89,7 @@ optimizers = {
     'adam': Adam(n_outer=10, lr=0.11)}
 
 monitors = {}
-log_alpha0 = np.log(0.1 * alpha_max)  # starting point
+alpha0 = alpha_max / 10  # starting point
 
 for optimizer_name in optimizer_names:
     estimator = LogisticRegression(

--- a/examples/plot_held_out_enet.py
+++ b/examples/plot_held_out_enet.py
@@ -131,13 +131,13 @@ ax.scatter(
     X, Y, s=10, c="orange", marker="o", label="$0$ order (grid search)",
     clip_on=False, cmap="viridis")
 ax.scatter(
-    monitor.alphas[:, 0]) / alpha_max,
-    monitor.alphas[:, 1]) / alpha_max,
+    monitor.alphas[:, 0] / alpha_max,
+    monitor.alphas[:, 1] / alpha_max,
     s=50, cmap=cmap, c=c,
     marker="X", label="$1$st order", clip_on=False)
 ax.set_xlim(X.min(), X.max())
 ax.set_ylim(Y.min(), Y.max())
-cb=fig.colorbar(cp)
+cb = fig.colorbar(cp)
 cb.set_label("Held-out loss")
 plt.xscale('log')
 plt.yscale('log')

--- a/examples/plot_held_out_enet.py
+++ b/examples/plot_held_out_enet.py
@@ -100,17 +100,17 @@ print("Started grad-search")
 t_grad_search = - time.time()
 monitor = Monitor()
 n_outer = 25
-log_alpha0 = np.array([np.log(alpha_max * 0.3), np.log(alpha_max / 10)])
+alpha0 = np.array([alpha_max * 0.3, alpha_max / 10])
 model = ElasticNet(max_iter=max_iter, estimator=estimator)
 criterion = HeldOutMSE(idx_train, idx_val)
 algo = ImplicitForward(tol_jac=1e-3, n_iter_jac=100, max_iter=max_iter)
 optimizer = GradientDescent(
     n_outer=n_outer, tol=tol, p_grad0=1.5, verbose=True)
 grad_search(
-    algo, criterion, model, optimizer, X, y, log_alpha0=log_alpha0,
+    algo, criterion, model, optimizer, X, y, alpha0=alpha0,
     monitor=monitor)
 t_grad_search += time.time()
-monitor.log_alphas = np.array(monitor.log_alphas)
+monitor.alphas = np.array(monitor.alphas)
 
 print("Time grid-search %f" % t_grid_search)
 print("Time grad-search %f" % t_grad_search)
@@ -131,13 +131,13 @@ ax.scatter(
     X, Y, s=10, c="orange", marker="o", label="$0$ order (grid search)",
     clip_on=False, cmap="viridis")
 ax.scatter(
-    np.exp(monitor.log_alphas[:, 0]) / alpha_max,
-    np.exp(monitor.log_alphas[:, 1]) / alpha_max,
+    monitor.alphas[:, 0]) / alpha_max,
+    monitor.alphas[:, 1]) / alpha_max,
     s=50, cmap=cmap, c=c,
     marker="X", label="$1$st order", clip_on=False)
 ax.set_xlim(X.min(), X.max())
 ax.set_ylim(Y.min(), Y.max())
-cb = fig.colorbar(cp)
+cb=fig.colorbar(cp)
 cb.set_label("Held-out loss")
 plt.xscale('log')
 plt.yscale('log')

--- a/examples/plot_held_out_lasso.py
+++ b/examples/plot_held_out_lasso.py
@@ -53,12 +53,11 @@ print("Starting path computation...")
 n_samples = len(y[idx_train])
 alpha_max = np.max(np.abs(X[idx_train, :].T.dot(y[idx_train])))
 alpha_max /= len(idx_train)
-log_alpha0 = np.log(alpha_max / 10)
+alpha0 = alpha_max / 10
 
 n_alphas = 10
 p_alphas = np.geomspace(1, 0.0001, n_alphas)
 alphas = alpha_max * p_alphas
-log_alphas = np.log(alphas)
 
 tol = 1e-7
 max_iter = 1e3
@@ -79,7 +78,7 @@ algo = Forward()
 monitor_grid_sk = Monitor()
 grid_search(
     algo, criterion, model, X, y, None, None, monitor_grid_sk,
-    log_alphas=log_alphas, tol=tol)
+    alphas=alphas, tol=tol)
 objs = np.array(monitor_grid_sk.objs)
 t_sk = time.time() - t0
 
@@ -99,7 +98,7 @@ algo = ImplicitForward()
 monitor_grad = Monitor()
 optimizer = LineSearch(n_outer=10, tol=tol)
 grad_search(
-    algo, criterion, model, optimizer, X, y, log_alpha0, monitor_grad)
+    algo, criterion, model, optimizer, X, y, alpha0, monitor_grad)
 
 t_grad_search = time.time() - t0
 
@@ -109,7 +108,7 @@ print('sparse-ho finished')
 # Plot results
 # ------------
 
-p_alphas_grad = np.exp(np.array(monitor_grad.log_alphas)) / alpha_max
+p_alphas_grad = np.array(monitor_grad.alphas) / alpha_max
 
 objs_grad = np.array(monitor_grad.objs)
 

--- a/examples/plot_lassoCV.py
+++ b/examples/plot_lassoCV.py
@@ -82,13 +82,13 @@ print('sparse-ho started')
 t0 = time.time()
 model = Lasso()
 criterion = HeldOutMSE(None, None)
-log_alpha0 = np.log(alpha_max / 10)
+alpha0 = alpha_max / 10
 monitor_grad = Monitor()
 cross_val_criterion = CrossVal(criterion, cv=kf)
 algo = ImplicitForward()
 optimizer = LineSearch(n_outer=10, tol=tol)
 grad_search(
-    algo, cross_val_criterion, model, optimizer, X, y, log_alpha0,
+    algo, cross_val_criterion, model, optimizer, X, y, alpha0,
     monitor_grad)
 
 t_grad_search = time.time() - t0
@@ -100,7 +100,7 @@ print('sparse-ho finished')
 # ------------
 objs = reg.mse_path_.mean(axis=1)
 
-p_alphas_grad = np.exp(np.array(monitor_grad.log_alphas)) / alpha_max
+p_alphas_grad = np.array(monitor_grad.alphas) / alpha_max
 objs_grad = np.array(monitor_grad.objs)
 
 

--- a/examples/plot_sparse_log_reg.py
+++ b/examples/plot_sparse_log_reg.py
@@ -55,17 +55,16 @@ n_samples = len(y[idx_train])
 alpha_max = np.max(np.abs(X[idx_train, :].T.dot(y[idx_train])))
 
 alpha_max /= 4 * len(idx_train)
-log_alpha_max = np.log(alpha_max)
-log_alpha_min = np.log(alpha_max / 100)
+alpha_max = alpha_max
+alpha_min = alpha_max / 100
 max_iter = 100
 
-log_alpha0 = np.log(0.1 * alpha_max)
+alpha0 = 0.1 * alpha_max
 tol = 1e-8
 
 n_alphas = 30
 p_alphas = np.geomspace(1, 0.0001, n_alphas)
 alphas = alpha_max * p_alphas
-log_alphas = np.log(alphas)
 
 ##############################################################################
 # Grid-search
@@ -81,8 +80,8 @@ criterion = HeldOutLogistic(idx_train, idx_val)
 algo_grid = Forward()
 monitor_grid = Monitor()
 grid_search(
-    algo_grid, criterion, model, X, y, log_alpha_min, log_alpha_max,
-    monitor_grid, log_alphas=log_alphas, tol=tol)
+    algo_grid, criterion, model, X, y, alpha_min, alpha_max,
+    monitor_grid, alphas=alphas, tol=tol)
 objs = np.array(monitor_grid.objs)
 
 t_sk = time.time() - t0
@@ -108,7 +107,7 @@ algo = ImplicitForward(tol_jac=tol, n_iter_jac=1000)
 
 optimizer = LineSearch(n_outer=10, tol=tol)
 grad_search(
-    algo, criterion, model, optimizer, X, y, log_alpha0,
+    algo, criterion, model, optimizer, X, y, alpha0,
     monitor_grad)
 
 objs_grad = np.array(monitor_grad.objs)
@@ -119,7 +118,7 @@ print('sparse-ho finished')
 print("Time to compute CV for sparse-ho: %.2f" % t_grad_search)
 
 
-p_alphas_grad = np.exp(np.array(monitor_grad.log_alphas)) / alpha_max
+p_alphas_grad = np.array(monitor_grad.alphas) / alpha_max
 
 objs_grad = np.array(monitor_grad.objs)
 

--- a/examples/plot_sparse_log_reg.py
+++ b/examples/plot_sparse_log_reg.py
@@ -95,7 +95,6 @@ print(f"Time to compute grad search: {t_grid_search:.2f} s")
 print('sparse-ho started')
 
 t0 = time.time()
-log_alpha0 = np.log(0.1 * alpha_max)  # initial point
 
 estimator = LogisticRegression(
     penalty='l1', fit_intercept=False, tol=tol)

--- a/examples/plot_use_callback.py
+++ b/examples/plot_use_callback.py
@@ -49,7 +49,7 @@ idx_train = np.arange(0, n_samples // 2)
 idx_val = np.arange(n_samples // 2, n_samples)
 
 alpha_max = np.max(np.abs(X[idx_train, :].T @ y[idx_train])) / len(idx_train)
-log_alpha0 = np.log(alpha_max / 10)
+alpha0 = alpha_max / 10
 
 estimator = linear_model.Lasso(
     fit_intercept=False, max_iter=1e5, warm_start=True)
@@ -75,7 +75,7 @@ algo = ImplicitForward()
 monitor = Monitor(callback=callback)
 optimizer = LineSearch(n_outer=30)
 
-grad_search(algo, criterion, model, optimizer, X, y, log_alpha0, monitor)
+grad_search(algo, criterion, model, optimizer, X, y, alpha0, monitor)
 
 ##############################################################################
 # Plot results

--- a/examples/plot_use_callback.py
+++ b/examples/plot_use_callback.py
@@ -59,7 +59,7 @@ estimator = linear_model.Lasso(
 objs_test = []
 
 
-def callback(val, grad, mask, dense, log_alpha):
+def callback(val, grad, mask, dense, alpha):
     # The custom quantity is added at each outer iteration:
     # here the prediction MSE on test data
     objs_test.append(mean_squared_error(X_test[:, mask] @ dense, y_test))

--- a/examples/plot_wlasso.py
+++ b/examples/plot_wlasso.py
@@ -82,7 +82,7 @@ print("Vanilla LassoCV: Mean-squared error on test data %f" % mse_cv)
 ##############################################################################
 # Weighted Lasso with sparse-ho.
 # We use the vanilla lassoCV coefficients as a starting point
-log_alpha0 = np.log(model_cv.alpha_) * np.ones(n_features)
+alpha0 = model_cv.alpha_ * np.ones(n_features)
 # Weighted Lasso: Sparse-ho: 1 param per feature
 estimator = Lasso(fit_intercept=False, max_iter=10, warm_start=True)
 model = WeightedLasso(estimator=estimator)
@@ -91,7 +91,7 @@ algo = ImplicitForward()
 monitor = Monitor()
 optimizer = LineSearch(n_outer=20, tol=1e-6, verbose=True)
 results = grad_search(
-    algo, criterion, model, optimizer, X, y, log_alpha0, monitor)
+    algo, criterion, model, optimizer, X, y, alpha0, monitor)
 ##############################################################################
 
 ##############################################################################

--- a/sparse_ho/criterion/cross_val.py
+++ b/sparse_ho/criterion/cross_val.py
@@ -57,7 +57,7 @@ class CrossVal(BaseCriterion):
             self.dict_crits[i].get_val(
                 self.dict_models[i], X, y, log_alpha, tol=tol) for i in range(
                     self.n_splits)])
-        monitor(val, None, log_alpha=log_alpha)
+        monitor(val, None, alpha=np.exp(log_alpha))
         return val
 
     def get_val_grad(
@@ -81,7 +81,7 @@ class CrossVal(BaseCriterion):
         else:
             grad = None
         if monitor is not None:
-            monitor(val, grad, log_alpha=log_alpha)
+            monitor(val, grad, alpha=np.exp(log_alpha))
         return val, grad
 
     def get_val_outer(cls, *args, **kwargs):

--- a/sparse_ho/criterion/held_out.py
+++ b/sparse_ho/criterion/held_out.py
@@ -48,7 +48,7 @@ class HeldOutMSE(BaseCriterion):
         value_outer = self.get_val_outer(
             X[self.idx_val, :], y[self.idx_val], mask, dense)
         if monitor is not None:
-            monitor(value_outer, None, log_alpha=log_alpha)
+            monitor(value_outer, None, alpha=np.exp(log_alpha))
         return value_outer
 
     def get_val_grad(
@@ -78,7 +78,7 @@ class HeldOutMSE(BaseCriterion):
         val = self.get_val_outer(X_val, y_val, mask, dense)
 
         if monitor is not None:
-            monitor(val, grad, mask, dense, log_alpha)
+            monitor(val, grad, mask, dense, alpha=np.exp(log_alpha))
         return val, grad
 
     def proj_hyperparam(self, model, X, y, log_alpha):
@@ -119,7 +119,7 @@ class HeldOutLogistic(BaseCriterion):
         val = self.get_val_outer(
             X[self.idx_val, :], y[self.idx_val], mask, dense)
         if monitor is not None:
-            monitor(val, None, mask, dense, log_alpha)
+            monitor(val, None, mask, dense, alpha=np.exp(log_alpha))
         return val
 
     def get_val_grad(
@@ -149,7 +149,7 @@ class HeldOutLogistic(BaseCriterion):
         mask, dense = model.get_beta(X_train, y_train, mask, dense)
         val = self.get_val_outer(X_val, y_val, mask, dense)
         if monitor is not None:
-            monitor(val, grad, mask, dense, log_alpha)
+            monitor(val, grad, mask, dense, alpha=np.exp(log_alpha))
 
         return val, grad
 
@@ -228,7 +228,7 @@ class HeldOutSmoothedHinge(BaseCriterion):
         val = self.get_val_outer(X_val, y_val, mask, dense)
 
         if monitor is not None:
-            monitor(val, grad, mask, dense, log_alpha)
+            monitor(val, grad, mask, dense, alpha=np.exp(log_alpha))
 
         return val, grad
 

--- a/sparse_ho/criterion/multiclass_logreg.py
+++ b/sparse_ho/criterion/multiclass_logreg.py
@@ -22,6 +22,7 @@ class LogisticMulticlass():
     ----------
         TODO
     """
+
     def __init__(self, idx_train, idx_val, algo, idx_test=None):
         self.idx_train = idx_train
         self.idx_val = idx_val
@@ -84,7 +85,7 @@ class LogisticMulticlass():
                   (val, acc_val))
 
         monitor(
-            val, log_alpha=log_alpha.copy(), grad=grad.copy(), acc_val=acc_val,
+            val, alpha=np.exp(log_alpha), grad=grad.copy(), acc_val=acc_val,
             acc_test=acc_test)
 
         self.all_betas = all_betas
@@ -113,7 +114,7 @@ class LogisticMulticlass():
         val = cross_entropy(
             all_betas, X[self.idx_val, :], self.one_hot_code[self.idx_val, :])
         monitor(
-            val, log_alpha=log_alpha.copy(), grad=None, acc_val=acc_val,
+            val, alpha=np.exp(log_alpha), grad=None, acc_val=acc_val,
             acc_test=acc_test)
         print("Value outer %f || Accuracy validation %f || Accuracy test %f" %
               (val, acc_val, acc_test))

--- a/sparse_ho/criterion/sure.py
+++ b/sparse_ho/criterion/sure.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy.linalg import norm
 from sklearn.utils import check_random_state
 
@@ -74,7 +75,7 @@ class FiniteDiffMonteCarloSure(BaseCriterion):
 
         val = self.get_val_outer(X, y, mask, dense, mask2, dense2)
         if monitor is not None:
-            monitor(val, None, mask, dense, log_alpha)
+            monitor(val, None, mask, dense, alpha=np.exp(log_alpha))
         return val
 
     def _init_delta_epsilon(self, X):
@@ -132,6 +133,6 @@ class FiniteDiffMonteCarloSure(BaseCriterion):
         else:
             grad = None
         if monitor is not None:
-            monitor(val, grad, mask, dense, log_alpha)
+            monitor(val, grad, mask, dense, alpha=np.exp(log_alpha))
 
         return val, grad

--- a/sparse_ho/grid_search.py
+++ b/sparse_ho/grid_search.py
@@ -8,67 +8,58 @@ except Exception:
 
 
 def grid_search(
-        algo, criterion, model, X, y, log_alpha_min, log_alpha_max, monitor,
+        algo, criterion, model, X, y, alpha_min, alpha_max, monitor,
         max_evals=50, tol=1e-5, nb_hyperparam=1,
-        beta_star=None, random_state=42, samp="grid", log_alphas=None,
+        beta_star=None, random_state=42, samp="grid", alphas=None,
         t_max=100_000, reverse=True):
-    if log_alphas is None and samp == "grid":
+    if alphas is None and samp == "grid":
         if reverse:
-            log_alphas = np.linspace(log_alpha_max, log_alpha_min, max_evals)
+            alphas = np.geomspace(alpha_max, alpha_min, max_evals)
         else:
-            log_alphas = np.linspace(log_alpha_min, log_alpha_max, max_evals)
+            alphas = np.linspace(alpha_min, alpha_max, max_evals)
         if nb_hyperparam == 2:
-            log_alphas = np.array(np.meshgrid(
-                log_alphas, log_alphas)).T.reshape(-1, 2)
+            alphas = np.array(np.meshgrid(
+                alphas, alphas)).T.reshape(-1, 2)
 
     elif samp == "random":
         rng = np.random.RandomState(random_state)
-        log_alphas = rng.uniform(
-            log_alpha_min, log_alpha_max, size=max_evals)
+        # sample uniformly on log scale
+        alphas = np.exp(rng.uniform(
+            np.log(alpha_min), np.log(alpha_max), size=max_evals))
         if reverse:
-            log_alphas = -np.sort(-log_alphas)
+            alphas = np.sort(alphas)[::-1]
         else:
-            log_alphas = np.sort(log_alphas)
+            alphas = np.sort(alphas)
         if nb_hyperparam == 2:
-            log_alphas2 = rng.uniform(
-                log_alpha_min, log_alpha_max, size=max_evals)
+            alphas2 = np.exp(rng.uniform(
+                np.log(alpha_min), np.log(alpha_max), size=max_evals))
             if reverse:
-                log_alphas2 = -np.sort(-log_alphas2)
+                alphas2 = np.sort(alphas2)[::-1]
             else:
-                log_alphas2 = np.sort(log_alphas2)
-            log_alphas = np.array(np.meshgrid(
-                log_alphas, log_alphas2)).T.reshape(-1, 2)
+                alphas2 = np.sort(alphas2)
+            alphas = np.array(np.meshgrid(
+                alphas, alphas2)).T.reshape(-1, 2)
 
     elif samp == "lhs":
-        xlimits = np.array([[log_alpha_min, log_alpha_max]])
+        xlimits = np.array([[np.log(alpha_min), np.log(alpha_max)]])
         sampling = LHS(xlimits=xlimits)
         num = max_evals
-        log_alphas = sampling(num)
-        log_alphas[log_alphas < log_alpha_min] = log_alpha_min
-        log_alphas[log_alphas > log_alpha_max] = log_alpha_max
+        alphas = np.exp(sampling(num))
+        alphas = np.clip(alphas, alpha_min, alpha_max)
     min_g_func = np.inf
-    log_alpha_opt = log_alphas[0]
+    alpha_opt = alphas[0]
 
-    # if nb_hyperparam == 2:
-    #     n_try = max_evals ** 2
-    # else:
-    #     n_try = log_alphas.shape[0]
-
-    for i, log_alpha in enumerate(log_alphas):
-        print("Iteration %i / %i" % (i+1, len(log_alphas)))
-        # try:
-        #     log_alpha = log_alphas[i, :]
-        # except Exception:
-        #     log_alpha = log_alphas[i]
+    for i, alpha in enumerate(alphas):
+        print("Iteration %i / %i" % (i+1, len(alphas)))
         if samp == "lhs":
-            log_alpha = log_alpha[0]
+            alpha = alpha[0]
         g_func = criterion.get_val(
-            model, X, y, log_alpha, monitor, tol=tol)
+            model, X, y, np.log(alpha), monitor, tol=tol)
 
         if g_func < min_g_func:
             min_g_func = g_func
-            log_alpha_opt = log_alpha
+            alpha_opt = alpha
 
         if monitor.times[-1] > t_max:
             break
-    return log_alpha_opt, min_g_func
+    return alpha_opt, min_g_func

--- a/sparse_ho/ho.py
+++ b/sparse_ho/ho.py
@@ -93,11 +93,8 @@ def hyperopt_wrapper(
 
     # TODO, also size_space = n_hyperparam ?
     space = [
-        hp.uniform(str(dim), log_alpha_min, log_alpha_max) for dim in range(
-            size_space)]
-
-    # space = hp.uniform(
-    #     'log_alpha', log_alpha_min, log_alpha_max)
+        hp.uniform(str(dim), np.log(alpha_min), np.log(alpha_max)) for
+        dim in range(size_space)]
 
     rng = check_random_state(random_state)
 

--- a/sparse_ho/ho.py
+++ b/sparse_ho/ho.py
@@ -15,7 +15,7 @@ from sklearn.utils import check_random_state
 
 
 def grad_search(
-        algo, criterion, model, optimizer, X, y, log_alpha0, monitor):
+        algo, criterion, model, optimizer, X, y, alpha0, monitor):
     """
     Parameters
     ----------
@@ -31,8 +31,8 @@ def grad_search(
         Design matrix.
     y: array like of shape (n_samples,)
         Target.
-    log_alpha0: float
-        initial value of the logarithm of the regularization coefficient alpha.
+    alpha0: float
+        initial value of the hyperparameter alpha.
     monitor: instance of Monitor
         used to store the value of the cross-validation function.
     """
@@ -46,11 +46,11 @@ def grad_search(
         return criterion.proj_hyperparam(model, X, y, log_alpha)
 
     return optimizer._grad_search(
-        _get_val_grad, _proj_hyperparam, log_alpha0, monitor)
+        _get_val_grad, _proj_hyperparam, np.log(alpha0), monitor)
 
 
 def hyperopt_wrapper(
-        algo, criterion, model, X, y, log_alpha_min, log_alpha_max, monitor,
+        algo, criterion, model, X, y, alpha_min, alpha_max, monitor,
         max_evals=50, tol=1e-5, random_state=42, t_max=100_000,
         method='bayesian', size_space=1):
     """
@@ -68,9 +68,9 @@ def hyperopt_wrapper(
         Design matrix.
     y: array like of shape (n_samples,)
         Target.
-    log_alpha_min: float
+    alpha_min: float
         minimum value for the regularization coefficient alpha.
-    log_alpha_max: float
+    alpha_max: float
         maximum value for the regularization coefficient alpha.
     monitor: instance of Monitor
         used to store the value of the cross-validation function.
@@ -91,6 +91,7 @@ def hyperopt_wrapper(
             model, X, y, log_alpha, monitor, tol=tol)
         return val_func
 
+    # TODO, also size_space = n_hyperparam ?
     space = [
         hp.uniform(str(dim), log_alpha_min, log_alpha_max) for dim in range(
             size_space)]

--- a/sparse_ho/optimizers/line_search_wolfe.py
+++ b/sparse_ho/optimizers/line_search_wolfe.py
@@ -40,7 +40,7 @@ class LineSearchWolfe(BaseOptimizer):
         for _ in range(self.n_outer):
             val, grad = _get_val_grad(log_alphak)
 
-            monitor(val.copy(), criterion.val_test, log_alphak,
+            monitor(val.copy(), criterion.val_test, np.exp(log_alphak),
                     grad, criterion.rmse)
 
             step_size = self.wolfe(

--- a/sparse_ho/optimizers/line_search_wolfe.py
+++ b/sparse_ho/optimizers/line_search_wolfe.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy.linalg import norm
 
 from sparse_ho.optimizers.base import BaseOptimizer

--- a/sparse_ho/tests/test_grid_search.py
+++ b/sparse_ho/tests/test_grid_search.py
@@ -127,7 +127,7 @@ def test_grid_search():
     monitor_random = Monitor()
     criterion = FiniteDiffMonteCarloSure(sigma=sigma_star)
     algo = Forward()
-    log_alpha_opt_random, _ = grid_search(
+    alpha_opt_random, _ = grid_search(
         algo, criterion, model, X, y, alpha_min, alpha_max,
         monitor_random,
         max_evals=max_evals, tol=1e-5, samp="random")

--- a/sparse_ho/tests/test_grid_search.py
+++ b/sparse_ho/tests/test_grid_search.py
@@ -30,9 +30,8 @@ idx_val = np.arange(50, 100)
 
 alpha_max = np.max(np.abs(X[idx_train, :].T @ y[idx_train])) / len(idx_train)
 
-log_alphas = np.log(alpha_max * np.geomspace(1, 0.1))
-log_alpha_max = np.log(alpha_max)
-log_alpha_min = np.log(0.0001 * alpha_max)
+alphas = alpha_max * np.geomspace(1, 0.1)
+alpha_min = 0.0001 * alpha_max
 
 estimator = linear_model.Lasso(
     fit_intercept=False, max_iter=10000, warm_start=True)
@@ -53,8 +52,6 @@ models["lasso_custom"] = Lasso(estimator=celer.Lasso(
 def test_cross_val_criterion(model_name, XX):
     model = models[model_name]
     alpha_min = alpha_max / 10
-    log_alpha_max = np.log(alpha_max)
-    log_alpha_min = np.log(alpha_min)
     max_iter = 10000
     n_alphas = 10
     kf = KFold(n_splits=5, shuffle=True, random_state=56)
@@ -67,7 +64,7 @@ def test_cross_val_criterion(model_name, XX):
     criterion = CrossVal(sub_crit, cv=kf)
     algo = Forward()
     grid_search(
-        algo, criterion, model, XX, y, log_alpha_min, log_alpha_max,
+        algo, criterion, model, XX, y, alpha_min, alpha_max,
         monitor_grid, max_evals=n_alphas, tol=tol)
 
     if model_name.startswith("lasso"):
@@ -99,31 +96,31 @@ def test_grid_search():
     model = Lasso(estimator=estimator)
     criterion = HeldOutMSE(idx_train, idx_train)
     algo = Forward()
-    log_alpha_opt_grid, _ = grid_search(
-        algo, criterion, model, X, y, log_alpha_min, log_alpha_max,
+    alpha_opt_grid, _ = grid_search(
+        algo, criterion, model, X, y, alpha_min, alpha_max,
         monitor_grid, max_evals=max_evals,
         tol=1e-5, samp="grid")
 
     monitor_random = Monitor()
     criterion = HeldOutMSE(idx_train, idx_val)
     algo = Forward()
-    log_alpha_opt_random, _ = grid_search(
-        algo, criterion, model, X, y, log_alpha_min, log_alpha_max,
+    alpha_opt_random, _ = grid_search(
+        algo, criterion, model, X, y, alpha_min, alpha_max,
         monitor_random,
         max_evals=max_evals, tol=1e-5, samp="random")
 
-    np.testing.assert_allclose(monitor_random.log_alphas[
-        np.argmin(monitor_random.objs)], log_alpha_opt_random)
-    np.testing.assert_allclose(monitor_grid.log_alphas[
-        np.argmin(monitor_grid.objs)], log_alpha_opt_grid)
+    np.testing.assert_allclose(monitor_random.alphas[
+        np.argmin(monitor_random.objs)], alpha_opt_random)
+    np.testing.assert_allclose(monitor_grid.alphas[
+        np.argmin(monitor_grid.objs)], alpha_opt_grid)
 
     monitor_grid = Monitor()
     model = Lasso(estimator=estimator)
 
     criterion = FiniteDiffMonteCarloSure(sigma=sigma_star)
     algo = Forward()
-    log_alpha_opt_grid, _ = grid_search(
-        algo, criterion, model, X, y, log_alpha_min, log_alpha_max,
+    alpha_opt_grid, _ = grid_search(
+        algo, criterion, model, X, y, alpha_min, alpha_max,
         monitor_grid, max_evals=max_evals,
         tol=1e-5, samp="grid")
 
@@ -131,14 +128,14 @@ def test_grid_search():
     criterion = FiniteDiffMonteCarloSure(sigma=sigma_star)
     algo = Forward()
     log_alpha_opt_random, _ = grid_search(
-        algo, criterion, model, X, y, log_alpha_min, log_alpha_max,
+        algo, criterion, model, X, y, alpha_min, alpha_max,
         monitor_random,
         max_evals=max_evals, tol=1e-5, samp="random")
 
-    np.testing.assert_allclose(monitor_random.log_alphas[
-        np.argmin(monitor_random.objs)], log_alpha_opt_random)
-    np.testing.assert_allclose(monitor_grid.log_alphas[
-        np.argmin(monitor_grid.objs)], log_alpha_opt_grid)
+    np.testing.assert_allclose(monitor_random.alphas[
+        np.argmin(monitor_random.objs)], alpha_opt_random)
+    np.testing.assert_allclose(monitor_grid.alphas[
+        np.argmin(monitor_grid.objs)], alpha_opt_grid)
 
 
 if __name__ == '__main__':

--- a/sparse_ho/tests/test_optimizers.py
+++ b/sparse_ho/tests/test_optimizers.py
@@ -84,7 +84,7 @@ def test_grad_search(model, crit):
     grad_search(algo, criterion, model, optimizer, X, y, log_alpha, monitor3)
 
     np.testing.assert_allclose(
-        np.array(monitor1.log_alphas), np.array(monitor3.log_alphas))
+        np.array(monitor1.alphas), np.array(monitor3.alphas))
     np.testing.assert_allclose(
         np.array(monitor1.grads), np.array(monitor3.grads), rtol=1e-5)
     np.testing.assert_allclose(

--- a/sparse_ho/tests/test_optimizers.py
+++ b/sparse_ho/tests/test_optimizers.py
@@ -29,17 +29,17 @@ idx_val = np.arange(50, 100)
 
 alpha_max = np.max(np.abs(X[idx_train, :].T @ y[idx_train])) / len(idx_train)
 p_alpha = 0.7
-alpha = p_alpha * alpha_max
-log_alpha = np.log(alpha)
+alpha0 = p_alpha * alpha_max
+# log_alpha = np.log(alpha)
 
 log_alphas = np.log(alpha_max * np.geomspace(1, 0.1))
 tol = 1e-16
 max_iter = 1000
 
-dict_log_alpha0 = {}
-dict_log_alpha0["lasso"] = log_alpha
-tab = np.linspace(1, 1000, n_features)
-dict_log_alpha0["wlasso"] = log_alpha + np.log(tab / tab.max())
+# dict_log_alpha0 = {}
+# dict_log_alpha0["lasso"] = log_alpha
+# tab = np.linspace(1, 1000, n_features)
+# dict_log_alpha0["wlasso"] = log_alpha + np.log(tab / tab.max())
 
 models = [
     Lasso(max_iter=max_iter, estimator=None),
@@ -69,19 +69,19 @@ def test_grad_search(model, crit):
     algo = Forward()
     optimizer = LineSearch(n_outer=n_outer, tol=1e-16)
     grad_search(
-        algo, criterion, model, optimizer, X, y, log_alpha, monitor1)
+        algo, criterion, model, optimizer, X, y, alpha0, monitor1)
 
     criterion = HeldOutMSE(idx_train, idx_val)
     monitor2 = Monitor()
     algo = Implicit()
     optimizer = LineSearch(n_outer=n_outer, tol=1e-16)
-    grad_search(algo, criterion, model, optimizer, X, y, log_alpha, monitor2)
+    grad_search(algo, criterion, model, optimizer, X, y, alpha0, monitor2)
 
     criterion = HeldOutMSE(idx_train, idx_val)
     monitor3 = Monitor()
     algo = ImplicitForward(tol_jac=1e-8, n_iter_jac=5000)
     optimizer = LineSearch(n_outer=n_outer, tol=1e-16)
-    grad_search(algo, criterion, model, optimizer, X, y, log_alpha, monitor3)
+    grad_search(algo, criterion, model, optimizer, X, y, alpha0, monitor3)
 
     np.testing.assert_allclose(
         np.array(monitor1.alphas), np.array(monitor3.alphas))

--- a/sparse_ho/tests/test_svm.py
+++ b/sparse_ho/tests/test_svm.py
@@ -118,21 +118,23 @@ def test_grad_search(model):
     monitor1 = Monitor()
     algo = Forward()
     optimizer = LineSearch(n_outer=n_outer, tol=1e-13)
+
+    C0 = 1e-3
     grad_search(
-        algo, criterion, model, optimizer, X, y, np.log(1e-3), monitor1)
+        algo, criterion, model, optimizer, X, y, C0, monitor1)
 
     criterion = HeldOutSmoothedHinge(idx_train, idx_val)
     monitor2 = Monitor()
     algo = Implicit()
     optimizer = LineSearch(n_outer=n_outer, tol=1e-13)
     grad_search(
-        algo, criterion, model, optimizer, X, y, np.log(1e-3), monitor2)
+        algo, criterion, model, optimizer, X, y, C0, monitor2)
 
     criterion = HeldOutSmoothedHinge(idx_train, idx_val)
     monitor3 = Monitor()
     algo = ImplicitForward(tol_jac=1e-6, n_iter_jac=100)
     grad_search(
-        algo, criterion, model, optimizer, X, y, np.log(1e-3), monitor3)
+        algo, criterion, model, optimizer, X, y, C0, monitor3)
 
     np.testing.assert_allclose(
         np.array(monitor1.alphas), np.array(monitor3.alphas))

--- a/sparse_ho/tests/test_svm.py
+++ b/sparse_ho/tests/test_svm.py
@@ -135,7 +135,7 @@ def test_grad_search(model):
         algo, criterion, model, optimizer, X, y, np.log(1e-3), monitor3)
 
     np.testing.assert_allclose(
-        np.array(monitor1.log_alphas), np.array(monitor3.log_alphas))
+        np.array(monitor1.alphas), np.array(monitor3.alphas))
     np.testing.assert_allclose(
         np.array(monitor1.grads), np.array(monitor3.grads), atol=1e-8)
     np.testing.assert_allclose(

--- a/sparse_ho/utils.py
+++ b/sparse_ho/utils.py
@@ -227,24 +227,24 @@ class Monitor():
         self.t0 = time.time()
         self.objs = []   # TODO rename, use self.value_outer?
         self.times = []
-        self.log_alphas = []
+        self.alphas = []
         self.grads = []
         self.callback = callback
         self.acc_vals = []
         self.all_betas = []
 
     def __call__(
-            self, obj, grad, mask=None, dense=None, log_alpha=None,
+            self, obj, grad, mask=None, dense=None, alpha=None,
             acc_val=None, acc_test=None):
         self.objs.append(obj)
         try:
-            self.log_alphas.append(log_alpha.copy())
+            self.alphas.append(alpha.copy())
         except Exception:
-            self.log_alphas.append(log_alpha)
+            self.alphas.append(alpha)
         self.times.append(time.time() - self.t0)
         self.grads.append(grad)
         if self.callback is not None:
-            self.callback(obj, grad, mask, dense, log_alpha)
+            self.callback(obj, grad, mask, dense, alpha)
         if acc_val is not None:
             self.acc_vals.append(acc_val)
         if acc_test is not None:


### PR DESCRIPTION
@QB3 @Klopfe up to where should we hide log_alpha ?

For me, everything the basic user needs to set: alpha_max, alpha_min, alpha0, monitor.alphas.

Higher level functions, like get_val_grad, get_val_grad, get_beta_jac can keep log_alpha (the generic user does not see them)

WDYT?